### PR TITLE
Time calculation and styling improvements

### DIFF
--- a/blackbg.css
+++ b/blackbg.css
@@ -1,0 +1,4 @@
+body {
+    background-color: black;
+    color: white;
+}

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Clock</title>
     <link rel="stylesheet" href="main.css">
+    <link rel="stylesheet" href="whitebg.css" id="colors">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,100..700;1,100..700&display=swap"
@@ -28,7 +29,7 @@
                     </li>
 
             <div class="buttons">
-                <button id="start" onclick="preflightChecks(event)">Start</button>
+                <button id="start" onclick="preflightChecks(event)" title="Calculate start and end times, starting at the next whole minute.">Calculate times</button>
                 <button id="reset" onclick="resetClock(event)">Reset</button>
             </div>
             </form>
@@ -48,7 +49,7 @@
                         <div id="endTime">&nbsp;</div>
                         <div id="endTimeStatus">&nbsp;</div>
                     </li>
-                    <li>
+                    <li id="extraTimeInfo">
                         Extra time
                         <div id="extraEndTime">&nbsp;</div>
                         <div id="extraEndTimeStatus">&nbsp;</div>

--- a/index.js
+++ b/index.js
@@ -1,30 +1,21 @@
 var endTime;
+var startTime;
 var extraTimeEnabled = false;
 var extraEndTime;
 var endTimeFinFlag = false;
 var extraEndTimeFinFlag = false;
+var startTimeFlag = false;
 var duration;
 
 function whiteBackground() {
-    const element = document.getElementsByTagName("body")[0];
-    if (element.style.backgroundColor != "white") {
-        element.style.backgroundColor = "white";
-    }
-    if (element.style.color != "black") {
-        element.style.color = "black";
-    }
-    //console.log("Background set to white")
+    const whitebgCSS = 'whitebg.css';
+    const colors = document.getElementById('colors');
+    colors.setAttribute('href', whitebgCSS);
 }
 
 function blackBackground() {
-    const element = document.getElementsByTagName("body")[0];
-    if (element.style.backgroundColor != "black") {
-        element.style.backgroundColor = "black";
-    }
-    if (element.style.color != "white") {
-        element.style.color = "white";
-    }
-    //console.log("Background set to black")
+    const blackbgCSS = 'blackbg.css';
+    colors.setAttribute('href', blackbgCSS);
 }
 
 function replaceWithNbsp(element) {
@@ -44,12 +35,16 @@ function resetGlobals() {
     extraEndTime = undefined;
     endTimeFinFlag = false;
     extraEndTimeFinFlag = false;
+    startTimeFlag = false;
+    startTime = undefined;
 }
 
 function resetClock(event) {
-    //console.log("Reset")
     event.preventDefault();
-    blackBackground();
+    whiteBackground();
+    if (checkExtraTime()) {
+        hideExtraTimeInfo();
+    }
     clearTimesAndStatuses();
     resetGlobals();
     //console.log("Clock reset");
@@ -73,6 +68,17 @@ function padWithLeadingZero(i) {
         i = "0" + i;
     }
     return i;
+}
+
+
+function hideExtraTimeInfo() {
+    const extraTimeInfoVisibility = document.getElementById('extraTimeInfo');
+    extraTimeInfoVisibility.style.display = 'none';
+}
+
+function showExtraTimeInfo() {
+    const extraTimeInfoVisibility = document.getElementById('extraTimeInfo');
+    extraTimeInfoVisibility.style.display = 'block';
 }
 
 function timeToStr(time) {
@@ -104,8 +110,16 @@ function extraEndTimeStatusSwitch() {
 
 }
 
+function startTimeStatusSwitch() {
+    blackBackground();
+    startTimeFlag = true;
+}
+
 function updateTime() {
     var now = getCurrentTime();
+    if (now >= startTime && startTimeFlag === false) {
+        startTimeStatusSwitch();
+    }
     if (now >= endTime && endTimeFinFlag === false) {
         endTimeStatusSwitch();
     } else if (extraTimeEnabled === true && now >= extraEndTime && extraEndTimeFinFlag === false) {
@@ -141,7 +155,7 @@ function preflightChecks(event) {
 }
 
 function checkExtraTime() {
-    var checkbox = document.getElementById("extraTimeToggle");
+    const checkbox = document.getElementById("extraTimeToggle");
     if (checkbox.checked == true) {
         extraTimeEnabled = true;
     } else {
@@ -150,11 +164,19 @@ function checkExtraTime() {
     //console.log("Extra time enabled: " + extraTimeEnabled);
 }
 
+function calculateNextNearestMinute(date) {
+    // Round given date to next nearest minute
+    const coefficient = 1000 * 60;
+    const roundedTime = new Date(Math.ceil(date.getTime() / coefficient) * coefficient);
+    return roundedTime;
+}
+
 function startExam() {
     const extraTimeMultiplier = 1.25;
     checkExtraTime();
     var minutes = duration;
-    var startTime = getCurrentTime()
+    startTime = getCurrentTime()
+    startTime = calculateNextNearestMinute(startTime);
     var startTimeStr = timeToStr(startTime);
     //console.log("startTime: " + startTime);
     //console.log("startTimeStr: " + startTimeStr);
@@ -173,7 +195,10 @@ function startExam() {
     document.getElementById("startTime").textContent = startTimeStr;
     document.getElementById("endTime").textContent = endTimeStr;
     if (extraTimeEnabled) {
+        showExtraTimeInfo();
         document.getElementById("extraEndTime").textContent = extraEndTimeStr;
+    } else {
+        hideExtraTimeInfo();
     }
 }
 

--- a/main.css
+++ b/main.css
@@ -4,8 +4,6 @@ html {
 
 body {
     font-family:'Roboto Mono', 'Courier New', Courier, monospace;
-    background-color: black;
-    color: white;
     height: 100%;
     margin: 0;
 }
@@ -37,7 +35,6 @@ body, html {
 
 #examSettings li {
     display: inline-block;
-    margin-right: 10px;
 }
 
 #extraTimeToggle {
@@ -63,12 +60,12 @@ body, html {
 }
 
 #clock {
-    font-size: 16vw;
+    font-size: 18vw;
 }
 
 .timeInfo {
     justify-content: center;
-    font-size: 3vw;
+    font-size: 4vw;
 }
 
 .timeInfo ul {
@@ -80,4 +77,8 @@ body, html {
 
 .timeInfo li {
     margin: 0 4vw;
+}
+
+#extraTimeInfo {
+    display: none;
 }

--- a/whitebg.css
+++ b/whitebg.css
@@ -1,0 +1,4 @@
+body {
+    background-color: white;
+    color: black;
+}


### PR DESCRIPTION
change extra time visibility depending on checkbox (applied on button press)
change default starting colors to white/black: when the exam starts, colors switch to black/white
change start time calculation to be next whole minute
change color stylying to be set in separate stylesheet
change size of clock and info fonts (slight increase)